### PR TITLE
feat: Specify mypy args in nvim-lint

### DIFF
--- a/.config/nvim/lua/configs/lint.lua
+++ b/.config/nvim/lua/configs/lint.lua
@@ -76,6 +76,15 @@ lint.linters["markdownlint-cli2"].cmd = function()
   end
 end
 
+lint.linters.mypy.args = {
+  "--show-column-numbers",
+  "--show-error-end",
+  "--hide-error-context",
+  "--no-color-output",
+  "--no-error-summary",
+  "--no-pretty",
+}
+
 lint.linters.mypy.cmd = function()
   local venv = vim.env.VIRTUAL_ENV
   if venv and vim.fn.filereadable(string.format("%s/bin/mypy", venv)) == 1 then


### PR DESCRIPTION
With default settings of nvim-lint, [mypy uses system python](https://github.com/mfussenegger/nvim-lint/blob/f707b3ae50417067fa63fdfe179b0bff6b380da1/lua/lint/linters/mypy.lua#L21-L24) instead of one in project's virtual environment.
In order for mypy to respect python in project's virtual environment over system python if mypy in virtual environment is used, this PR specifies mypy args in nvim-lint without `--python-executable` option.