### PR TITLE
feat: Add python3 as prerequisite apt packages

### DIFF
--- a/check_prerequisites.sh
+++ b/check_prerequisites.sh
@@ -34,6 +34,7 @@ apt_packages=(
   "libyaml-dev"
   "make"
   "patch"
+  "python3"
   "rustc"
   "unzip"
   "uuid-dev"


### PR DESCRIPTION
python3 is necessary when installing on Docker because [installing poetry with mise depends on python3](https://github.com/mise-plugins/mise-poetry/blob/main/bin/install#L46-L50).
Without adding python3 as prerequisite apt packages poetry installation fails on Docker as python3 is not included in ubuntu base image.