### PR TITLE
feat: Lazy-load copilot.nvim

### DIFF
--- a/.config/nvim/lua/plugins/init.lua
+++ b/.config/nvim/lua/plugins/init.lua
@@ -69,7 +69,7 @@ return {
 
   {
     "github/copilot.vim",
-    event = "VeryLazy",
+    event = "BufReadPost",
     config = function()
       vim.cmd [[
         imap <silent><script><expr> <C-J> copilot#Accept("\<CR>")


### PR DESCRIPTION
Load copilot.nvim with BufReadPost event as it is not necessary at startup