### PR TITLE
feat: Introduce git-blame.nvim

### DIFF
--- a/.config/nvim/lazy-lock.json
+++ b/.config/nvim/lazy-lock.json
@@ -15,6 +15,7 @@
   "diffview.nvim": { "branch": "main", "commit": "4516612fe98ff56ae0415a259ff6361a89419b0a" },
   "fidget.nvim": { "branch": "main", "commit": "d855eed8a06531a7e8fd0684889b2943f373c469" },
   "friendly-snippets": { "branch": "main", "commit": "de8fce94985873666bd9712ea3e49ee17aadb1ed" },
+  "git-blame.nvim": { "branch": "master", "commit": "2883a7460f611c2705b23f12d58d398d5ce6ec00" },
   "gitsigns.nvim": { "branch": "main", "commit": "863903631e676b33e8be2acb17512fdc1b80b4fb" },
   "indent-blankline.nvim": { "branch": "master", "commit": "e7a4442e055ec953311e77791546238d1eaae507" },
   "lazy.nvim": { "branch": "main", "commit": "1159bdccd8910a0fd0914b24d6c3d186689023d9" },

--- a/.config/nvim/lua/plugins/init.lua
+++ b/.config/nvim/lua/plugins/init.lua
@@ -215,4 +215,10 @@ return {
   },
 
   { "OXY2DEV/markview.nvim", ft = "markdown" },
+
+  {
+    "f-person/git-blame.nvim",
+    event = "BufReadPost",
+    opts = {},
+  },
 }


### PR DESCRIPTION
Introduce git-blame.nvim to show git blame information

![Screenshot from 2024-10-19 23-27-32](https://github.com/user-attachments/assets/192c4027-0863-4333-b464-c6ff5fcfcaa7)
