### PR TITLE
feat: Adjust install scripts and .zprofile for installation on macOS

### DIFF
--- a/.zprofile
+++ b/.zprofile
@@ -10,3 +10,15 @@ if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
 
+if [ "$(uname -s)" = "Darwin" ]; then
+  ARCH="$(uname -m)"
+  if [ "$ARCH" = "arm64" ]; then
+    if [ -e /opt/homebrew/bin/brew ]; then
+      eval "$(/opt/homebrew/bin/brew shellenv)"
+    fi
+  elif [ "$ARCH" = "x86_64" ]; then
+    if [ -e /usr/local/bin/brew ]; then
+      eval "$(/usr/local/bin/brew shellenv)"
+    fi
+  fi
+fi

--- a/scripts/00_check_prerequisites.sh
+++ b/scripts/00_check_prerequisites.sh
@@ -90,6 +90,7 @@ check_brew_packages() {
   if ! command -v brew &> /dev/null; then
     echo "Homebrew is not installed. Installing Homebrew..."
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    eval "$(/opt/homebrew/bin/brew shellenv)"
   fi
   brew upgrade
 

--- a/scripts/02_install_dev_tools.sh
+++ b/scripts/02_install_dev_tools.sh
@@ -15,6 +15,13 @@ case "$(uname -s)" in
     ;;
 esac
 
+install_starship() {
+  if [ ! -d /usr/local/bin ]; then
+    sudo mkdir -p /usr/local/bin
+  fi
+  sh -c "$(curl -sS https://starship.rs/install.sh)" -y -f
+}
+
 install_mise() {
   if [ ! -d ${HOME}/.local/share/mise ]; then
     curl https://mise.run | sh
@@ -95,7 +102,7 @@ install_npm_packages() {
   echo "npm packages installed."
 }
 
-sh -c "$(curl -sS https://starship.rs/install.sh)" -y -f & pids+=($!)
+install_starship & pids+=($!)
 install_mise & pids+=($!)
 install_sheldon & pids+=($!)
 install_neovim & pids+=($!)


### PR DESCRIPTION
- Add path to brew command in .zprofile in case of macOS
- Add path to brew command in 00_check_prerequisites.sh after installing brew
- Make /usr/local/bin directory if not exists before installing starship