### PR TITLE
feat: Install neovim and aws-sso-cli with mise, install awscli

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,11 +1,13 @@
 [tools]
 actionlint = "latest"
+aws-sso-cli = "latest"
 ecspresso = "latest"
 github-cli = "latest"
 go = "latest"
 hadolint = "latest"
 lua = "latest"
 lua-language-server = "latest"
+neovim = "latest"
 node = "20.12.2"
 poetry = "latest"
 python = "3.11.9"

--- a/scripts/02_install_dev_tools.sh
+++ b/scripts/02_install_dev_tools.sh
@@ -54,19 +54,20 @@ install_typos_lsp() {
 
 # awscli cannot be installed without Rosetta 2 on macOS with mise
 install_awscli() {
-  echo "Installing awscli..."
-  if [ "${machine}" = "Linux" ]; then
-    curl -o awscli.tar.gz https://awscli.amazonaws.com/awscli-2.18.15.tar.gz
-    tar -xzf awscli-2.18.15.tar.gz
-    rm awscli-2.18.15.tar.gz
-    cd awscli-2.18.15
-    make
-    make install
-    cd ../
-  elif [ "${machine}" = "macOS" ]; then
-    brew install awscli
+  if ! command -v aws &> /dev/null; then
+    echo "Installing awscli..."
+    if [ "${machine}" = "Linux" ]; then
+      curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
+      unzip -u awscliv2.zip
+      sudo ./aws/install
+      rm -r ./aws
+    elif [ "${machine}" = "macOS" ]; then
+      brew install awscli
+    fi
+    echo "awscli installed."
+  else
+    echo "awscli is already installed."
   fi
-  echo "awscli installed."
 }
 
 install_taplo_cli() {

--- a/scripts/02_install_dev_tools.sh
+++ b/scripts/02_install_dev_tools.sh
@@ -41,6 +41,7 @@ install_sheldon() {
 
 install_typos_lsp() {
   echo "Installing typos-lsp..."
+  mkdir -p ${HOME}/bin
   if [ "${machine}" = "Linux" ]; then
     curl -fsSL https://github.com/tekumara/typos-lsp/releases/download/v0.1.27/typos-lsp-v0.1.27-x86_64-unknown-linux-gnu.tar.gz \
       | tar xz -C ${HOME}/bin

--- a/scripts/02_install_dev_tools.sh
+++ b/scripts/02_install_dev_tools.sh
@@ -39,19 +39,6 @@ install_sheldon() {
   fi
 }
 
-install_neovim() {
-  mkdir -p ${HOME}/bin ${HOME}/lib ${HOME}/share
-  echo "Installing NeoVim..."
-  if [ "${machine}" = "Linux" ]; then
-    curl -fsSL https://github.com/neovim/neovim/releases/download/v0.10.2/nvim-linux64.tar.gz \
-      | tar xz --strip-components=1 -C ${HOME}
-  elif [ "${machine}" = "macOS" ]; then
-    curl -fsSL https://github.com/neovim/neovim/releases/download/v0.10.2/nvim-macos-arm64.tar.gz \
-      | tar xz --strip-components=1 -C ${HOME}
-  fi
-  echo "NeoVim installed."
-}
-
 install_typos_lsp() {
   echo "Installing typos-lsp..."
   if [ "${machine}" = "Linux" ]; then
@@ -62,6 +49,23 @@ install_typos_lsp() {
       | tar xz -C ${HOME}/bin
   fi
   echo "typos-lsp installed."
+}
+
+# awscli cannot be installed without Rosetta 2 on macOS with mise
+install_awscli() {
+  echo "Installing awscli..."
+  if [ "${machine}" = "Linux" ]; then
+    curl -o awscli.tar.gz https://awscli.amazonaws.com/awscli-2.18.15.tar.gz
+    tar -xzf awscli-2.18.15.tar.gz
+    rm awscli-2.18.15.tar.gz
+    cd awscli-2.18.15
+    make
+    make install
+    cd ../
+  elif [ "${machine}" = "macOS" ]; then
+    brew install awscli
+  fi
+  echo "awscli installed."
 }
 
 install_taplo_cli() {
@@ -105,7 +109,6 @@ install_npm_packages() {
 install_starship & pids+=($!)
 install_mise & pids+=($!)
 install_sheldon & pids+=($!)
-install_neovim & pids+=($!)
 install_typos_lsp & pids+=($!)
 
 rv=0
@@ -119,6 +122,7 @@ fi
 
 eval "$(~/.local/bin/mise activate bash)"
 export PATH="$HOME/.local/share/mise/shims:$PATH"
+install_awscli & pids+=($!)
 install_taplo_cli & pids+=($!)
 install_gems & pids+=($!)
 install_npm_packages & pids+=($!)


### PR DESCRIPTION
- Install NeoVim with mise, not from prebuilt source
- Install aws-sso-cli with mise
- Install awscli
  - install from the following source (not install with mise because currently prebuilt source install is not compatible with macOS without Rosetta 2)
    - from prebuilt source if Linux
    - from homebrew if macOS